### PR TITLE
Add biocViews to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+biocViews: 
 Imports:
     Seurat,
     dplyr,


### PR DESCRIPTION
Bioconductor packages like fgsea can't be found without specifying `biocViews:`.